### PR TITLE
Included Arithmetic expansion for fix for #18

### DIFF
--- a/labs/lab06/index.md
+++ b/labs/lab06/index.md
@@ -282,7 +282,7 @@ Armed with this, the rest of the required concepts for the shell script are in f
 
 As you are going through the tutorial, if there is a Unix command that you do not know (or you once knew and have since forgotten), you can find out more information about that command by entering `man command` at the Unix prompt.  This brings up the manual for that command, including all of the command-line parameters.
 
-A few thoughts to help you with your shell script.  If you are unsure if something is working, you can always print out the value of the variable through the `echo` command.  And you need not worry about the decimal precision of the average -- the result of using 'expr' with the sum over the number of runs is fine -- recall that the script has been modified to only print out an integer value (using 'expr' with floating point values will have issues).
+A few thoughts to help you with your shell script.  If you are unsure if something is working, you can always print out the value of the variable through the `echo` command.  And you need not worry about the decimal precision of the average -- the result of using 'expr' or arithmetic expansion `$(( ... ))` with the sum over the number of runs is fine -- recall that the script has been modified to only print out an integer value (using 'expr' or arithmetic expansion `$(( ... ))` with floating point values will have issues).
 
 Your script should have comments (anything on a line after a '#' is a comment).  Our solution was 10-15 lines, not counting comments.
 


### PR DESCRIPTION
Mentioned Arithmetic expansion syntax `$(( ... ))` along with expr.

Also, edited the Wikibook on Bash Scripting to include expr (assuming they accept the changes) - see http://en.wikibooks.org/w/index.php?title=Bash_Shell_Scripting#expr_.28deprecated.29.
