### PR TITLE
add homebrew option for doxygen install for use in mac terminal. ...

### DIFF
--- a/tutorials/11-doxygen/index.html
+++ b/tutorials/11-doxygen/index.html
@@ -41,5 +41,6 @@ double average (double x, double y) {
 <p>Private members are not documented in Doxygen by default. To change this (i.e. to document private members), you will want to change the <code>EXTRACT_PRIVATE</code> flag in Doxyfile to <code>YES</code>.</p>
 <p>You may have to include all of your comments in your .h file. This depends less on the doxygen version, and more on how you structure your code comments, but if you are making changes to your doxygen comments and are not seeing the results, try moving them to the .h file. As long as the documentation is created when <code>doxygen</code> is run, we don't really care where your doxygen comments are in your source code.</p>
 <p>To get doxygen working on the Mac, you will have to copy two binaries in /Applications/Doxgyen.app/Contents/Resources/ (or similar) to /usr/bin if you want to run it via the Makefile.</p>
+<p>Alternatively, if you have <a href="http://brew.sh/">homebrew</a> installed on your Mac, you can brew install doxygen from the command line with the command found <a href="http://brewformulas.org/Doxygen">here</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
...Much easier and CS students with Mac should probably know about homebrew sooner than rather than later because it saves you SO MUCH TIME AND HEADACHE installing software. Yay!!
