### PR TITLE
Fixed memory leak error upon exit

### DIFF
--- a/labs/lab02/ListTest.cpp
+++ b/labs/lab02/ListTest.cpp
@@ -81,6 +81,8 @@ int   main ()
                 cin  >> response;
 
                 if (response[0] == 'y' || response[0] == 'Y') {                 // Normal Exit
+                    if (list != NULL) delete list;
+                    if (itr != NULL) delete itr;
                     return 0;
                 }
 


### PR DESCRIPTION
Current CS 2150 student. After running executable for lab 2 under Valgrind, memory leaks were traced to this file. Including these deallocation calls before exiting the test harness caused the memory leaks to go away.