### PR TITLE
Fixed case 6 in Lab02's ListTest.cpp

### DIFF
--- a/labs/lab02/ListTest.cpp
+++ b/labs/lab02/ListTest.cpp
@@ -163,6 +163,7 @@ int   main ()
             case 6:                      // test last()
                 if (list == NULL) {
                     cout << endl << "\tCreate a List first." << endl;
+                    break;
                 }
                 cout << "\tSetting the ListItr to the last element..." << endl;
                 itr = new ListItr((list->last()));

--- a/labs/lab02/ListTest.cpp.html
+++ b/labs/lab02/ListTest.cpp.html
@@ -174,6 +174,7 @@ http://www.gnu.org/software/src-highlite">
             <b><font color="#0000FF">case</font></b> <font color="#993399">6</font><font color="#990000">:</font>                      <i><font color="#9A1900">// test last()</font></i>
                 <b><font color="#0000FF">if</font></b> <font color="#990000">(</font>list <font color="#990000">==</font> NULL<font color="#990000">)</font> <font color="#FF0000">{</font>
                     cout <font color="#990000">&lt;&lt;</font> endl <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Create a List first."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+                    <b><font color="#0000FF">break</font></b><font color="#990000">;</font>
                 <font color="#FF0000">}</font>
                 cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"</font><font color="#CC33CC">\t</font><font color="#FF0000">Setting the ListItr to the last element..."</font> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
                 itr <font color="#990000">=</font> <b><font color="#0000FF">new</font></b> <b><font color="#000000">ListItr</font></b><font color="#990000">((</font>list<font color="#990000">-&gt;</font><b><font color="#000000">last</font></b><font color="#990000">()));</font>


### PR DESCRIPTION
It was [pointed out on Piazza](https://piazza.com/class/idp70cbq8vk21l?cid=127#) that there was a bug in case 6 of ListTest.cpp, where one could encounter a segfault due to the code in the test harness.  This just adds the missing `break;` statement so it actually avoids the segfault instead of just detecting something will be wrong.