### PR TITLE
Fix typo in LLDB command page for displaying registers

### DIFF
--- a/docs/lldb_summary.md
+++ b/docs/lldb_summary.md
@@ -6,7 +6,7 @@ PDR: Docs: LLDB Command Summary
 Assembly-specific commands
 
 - `stepi`: step one MACHINE instruction (i.e. assembly instruction), instead of one C++ instruction (which is what `step` does)
-- `registers read`: display the values in the registers
+- `register read`: display the values in the registers
 - `settings set target.x86-disassembly-flavor intel`: set the assembly output format to what we are used to in class (and what we are programming in)
 - `disassemble`: like list, but displays the lines of assembly code currently being executed.
 - `disassemble --name (function)`: prints the assembly code for the supplied function (up until the next label)


### PR DESCRIPTION
This might mess with people if they decide to use LLDB for any part of Lab 8 or 9.