### PR TITLE
Add debug flag to NASM command

### DIFF
--- a/labs/lab08/Makefile
+++ b/labs/lab08/Makefile
@@ -11,7 +11,7 @@ CXXFLAGS	= -Wall -g
 AS	= nasm
 
 # Defines the flags for the assembler
-ASFLAGS	= -f elf
+ASFLAGS	= -f elf -g
 
 # All of the .o files for our program
 OFILES	= vecsum.o main.o


### PR DESCRIPTION
Pre-Lab 8 says NASM doesn't support debugging symbols, but it actually does, at least on Linux. For elf, the -g flag defaults to the 'stabs' debug format, but for macho it defaults to the dummy 'null' debug format.

Adding the flag won't hurt on any system, and it will add debug symbols on systems for which NASM has debug support.