### PR TITLE
Fix for #124

### DIFF
--- a/ibcm/ibcm-parse.cpp
+++ b/ibcm/ibcm-parse.cpp
@@ -43,6 +43,9 @@ int main (int argc, char *argv[]) {
             // is it the last line of the file?
             if ( (line.size() == 0) && (!file.good()) )
                 break;
+            // is the line empty?
+            if ( (line.size() == 0) )
+                continue;
             // is it a `//` comment?
             else if ( allowComments && (line.size() >= 2) &&
                     (line[0] == '/') && (line[1] == '/') )

--- a/ibcm/ibcm-parse.cpp
+++ b/ibcm/ibcm-parse.cpp
@@ -43,9 +43,13 @@ int main (int argc, char *argv[]) {
             // is it the last line of the file?
             if ( (line.size() == 0) && (!file.good()) )
                 break;
-            // is it a comment?
+            // is it a `//` comment?
             if ( allowComments && (line.size() >= 2) &&
                     (line[0] == '/') && (line[1] == '/') )
+                continue;
+            // is it a `#` comment?
+            if ( allowComments && (line.size() >= 1) &&
+                    (line[0] == '#') )
                 continue;
             // is the line too short?
             if ( line.size() < 4 ) {

--- a/ibcm/ibcm-parse.cpp
+++ b/ibcm/ibcm-parse.cpp
@@ -95,9 +95,10 @@ void printHelp(char *name) {
 
     helpPrinted = true;
 
-    cout << "Usage: " << name << " [option] IBCM_FILE" << endl;
+    cout << "Usage: " << name << " [option] <inputfile>" << endl;
     cout << "Options:" << endl;
-    cout << "\t[-allowcomments]\tAllows IBCM_FILE to contain lines beginning with `//` and `#`." << endl;
+    cout << "\t[-allowcomments]\tAllows file specified by <inputfile> to contain" << endl
+         << "\t\t\t\tlines beginning with `//` and `#`." << endl;
     cout << "\t[-help]\t\t\tPrints this help message." << endl;
 }
 

--- a/ibcm/ibcm-parse.cpp
+++ b/ibcm/ibcm-parse.cpp
@@ -14,6 +14,9 @@
 
 using namespace std;
 
+void printHelp(char* name);
+bool isEmpty(string& line);
+
 int main (int argc, char *argv[]) {
     string line;
     int linenum = 0;
@@ -24,11 +27,25 @@ int main (int argc, char *argv[]) {
         exit(1);
     }
     for ( int i = 1; i < argc; i++ ) {
+        // print the help description
+        if ( !strcmp(argv[i], "-help") ) {
+            printHelp(argv[0]);
+            exit(0);
+        }
+
+        // a comment has a '#' as the first character on a line or
         // a comment has a '//' as the first two characters on a line
         if ( !strcmp(argv[i],"-allowcomments") ) {
             allowComments = true;
             continue;
         }
+        
+        if ( argv[i][0] == '-' ) {
+            cout << argv[0] << ": " << argv[i] << ": no such argument" << endl;
+            printHelp(argv[0]);
+            exit(1);
+        }
+
         // open the file
         ifstream file(argv[i]);
         if ( !file.is_open() ) {
@@ -43,8 +60,8 @@ int main (int argc, char *argv[]) {
             // is it the last line of the file?
             if ( (line.size() == 0) && (!file.good()) )
                 break;
-            // is the line empty?
-            if ( (line.size() == 0) )
+            // is the line empty or all whitespace?
+            if ( isEmpty(line) )
                 continue;
             // is it a `//` comment?
             else if ( allowComments && (line.size() >= 2) &&
@@ -62,7 +79,7 @@ int main (int argc, char *argv[]) {
             // are the first four digits hex characters?
             for ( int j = 0; j < 4; j++ )
                 if ( !isxdigit(line[j]) ) {
-                    cout << argv[0] << ": " << argv[i] << " invalid hexadecimal digit on line " << linenum << " character " << (j+1) << endl;
+                    cout << argv[0] << ": " << argv[i] << " invalid hexadecimal digit '" << line[j] << "' on line " << linenum << " character " << (j+1) << endl;
                     exit(3);
                 }
         }
@@ -70,4 +87,33 @@ int main (int argc, char *argv[]) {
         file.close();
     }
     return 0;
+}
+
+void printHelp(char *name) {
+    static bool helpPrinted; // Static values are initialized to 0 or 0-equivalent
+    if(helpPrinted) return;
+
+    helpPrinted = true;
+
+    cout << "Usage: " << name << " [option] IBCM_FILE" << endl;
+    cout << "Options:" << endl;
+    cout << "\t[-allowcomments]\tAllows IBCM_FILE to contain lines beginning with `//` and `#`." << endl;
+    cout << "\t[-help]\t\t\tPrints this help message." << endl;
+}
+
+bool isEmpty(string& line) {
+    // is the line empty?
+    if ( line.empty() ) {
+        return true;
+    }
+
+    // does the line contain spaces or carriage returns?
+    else if ( line.find_first_not_of(' ') != line.npos &&
+              line.find_first_not_of('\n') != line.npos && 
+              line.find_first_not_of('\r') != line.npos) {
+        return false;
+    }
+
+    // otherwise, the line is basically empty
+    return true;
 }

--- a/ibcm/ibcm-parse.cpp
+++ b/ibcm/ibcm-parse.cpp
@@ -44,15 +44,15 @@ int main (int argc, char *argv[]) {
             if ( (line.size() == 0) && (!file.good()) )
                 break;
             // is it a `//` comment?
-            if ( allowComments && (line.size() >= 2) &&
+            else if ( allowComments && (line.size() >= 2) &&
                     (line[0] == '/') && (line[1] == '/') )
                 continue;
             // is it a `#` comment?
-            if ( allowComments && (line.size() >= 1) &&
+            else if ( allowComments && (line.size() >= 1) &&
                     (line[0] == '#') )
                 continue;
             // is the line too short?
-            if ( line.size() < 4 ) {
+            else if ( line.size() < 4 ) {
                 cout << argv[0] << ": " << argv[i] << " has too short a line on line number " << linenum << "(" << line.size() << ")" << endl;
                 exit(3);
             }

--- a/ibcm/simulator.php
+++ b/ibcm/simulator.php
@@ -57,11 +57,13 @@ function load_ibcm_file () {
 
       //Check old file format
       while( !feof($fp) ) {
-	$line = fgets($fp);
+	$line = fgets($fp).trim();
 	if ( $line == "" )
 	  continue;
 	if ( substr($line,0,2) == "//" )
 	  continue;
+        if ( substr($line,0,1) == "#"  )
+          continue;
 	$mem[$n++] = substr($line,0,4);
       }
       $top = 100;


### PR DESCRIPTION
This PR adds:

- the ability for the C/C++ IBCM compiler to skip over blank lines, lines with only spaces, and lines with carriage-returns or newlines.
- `#` as a comment (in addition to `//`)
- `-help` option 

in ibcm-parse.cpp and

- whitespace trimming and `#`-handling 

in simulator.php