### PR TITLE
fixed ibcm not description in table

### DIFF
--- a/slides/07-ibcm.html
+++ b/slides/07-ibcm.html
@@ -342,7 +342,7 @@ store 300
 <tr><td>7</td><td>and</td><td><code>a := a &and; mem[addr]</code></td><td>logical 'and' memory into accumulator</td></tr>
 <tr><td>8</td><td>or</td><td><code>a := a &or; mem[addr]</code></td><td>logical 'or' memory into accumulator</td></tr>
 <tr><td>9</td><td>xor</td><td><code>a := a &oplus; mem[addr]</code></td><td>logical 'xor' memory into accumulator</td></tr>
-<tr><td>A</td><td>not</td><td><code>a := !a</code></td><td>logical complement of accumulator</td></tr>
+<tr><td>A</td><td>not</td><td><code>a := ~a</code></td><td>logical complement of accumulator</td></tr>
 <tr><td>B</td><td>nop</td><td><code>/* */</code></td><td>do nothing (no operation)</td></tr>
 <tr><td>C</td><td>jmp</td><td><code>goto addr</code></td><td>jump to 'addr'</td></tr>
 <tr><td>D</td><td>jmpe</td><td><code>if a == 0 goto addr</code></td><td>jump to 'addr' if accumulator equals zero</td></tr>


### PR DESCRIPTION
The logical (bitwise) not should be a ~, not a !, which would be a boolean not