### PR TITLE
small correctness fixes

### DIFF
--- a/slides/08-assembly-64bit.html
+++ b/slides/08-assembly-64bit.html
@@ -473,7 +473,7 @@ loop:  	mov rcx, [i]
 	cmp rcx, [n]
 	jg endOfLoop
 	add [sum], rcx
-	inc [i]
+	inc qword [i]
 	jmp loop
 endOfLoop:
 </code></pre></td></tr></table>

--- a/tutorials/09-c/index.html
+++ b/tutorials/09-c/index.html
@@ -184,7 +184,7 @@ void main() {
 <h2 id="derived-types">Derived types</h2>
 <p>Like C++, C allows programmers to derive types from existing types. There are several kinds of derived types, including <em>structures</em>, <em>unions</em>, and <em>enumerated types</em>.</p>
 <h3 id="struct">struct</h3>
-<p>C++ does not have classes, but it does have structures. Early versions of C++ were called <em>C with Classes</em>; the C++ &quot;compiler&quot; was little more than a preprocessor, and <em>class</em> syntactical constructs were converted to structures so that the output could be compiled by a C compiler.</p>
+<p>C does not have classes, but it does have structures. Early versions of C++ were called <em>C with Classes</em>; the C++ &quot;compiler&quot; was little more than a preprocessor, and <em>class</em> syntactical constructs were converted to structures so that the output could be compiled by a C compiler.</p>
 <p>A structure definition has the following format:</p>
 <pre><code>struct name {
   type1 member1;

--- a/tutorials/09-c/index.md
+++ b/tutorials/09-c/index.md
@@ -206,7 +206,7 @@ Like C++, C allows programmers to derive types from existing types.  There are s
 
 ### struct ###
 
-C++ does not have classes, but it does have structures.  Early versions of C++ were called *C with Classes*; the C++ "compiler" was little more than a preprocessor, and *class* syntactical constructs were converted to structures so that the output could be compiled by a C compiler.
+C does not have classes, but it does have structures.  Early versions of C++ were called *C with Classes*; the C++ "compiler" was little more than a preprocessor, and *class* syntactical constructs were converted to structures so that the output could be compiled by a C compiler.
 
 A structure definition has the following format:
 


### PR DESCRIPTION
* Tutorial says "C++ does not have classes" when it should be "C"
* Example assembly code in the slides does compile unless an operation width is specified for the `inc` instruction.