### PR TITLE
Refactor markdown to html script

### DIFF
--- a/utils/convert-markdown-to-html
+++ b/utils/convert-markdown-to-html
@@ -7,7 +7,7 @@ for infile in `find . -type f -name '*.md' | grep -v 'reveal\.js'`; do
     # derive output file name (replace .md with .html)
     outfile=`echo $infile | sed 's/md$/html/g'`
     # calculate relative path from any file in a subdirectory to another (CSS) in the root directory
-    pathprefix=`echo "$infile" | tr -d -c '/' | sed -r 's/^\///g' | sed -r 's/\//..\//g'`
+    pathprefix=`echo ${infile:2} | tr -d -c '/' | sed -r 's/\//..\//g'`
     # perform the conversion from MD to HTML, linking CSS in the process
     pandoc -V "pagetitle:$lineone" -f markdown -c ${pathprefix}markdown.css -t html -o $outfile $infile
 done

--- a/utils/convert-markdown-to-html
+++ b/utils/convert-markdown-to-html
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # take every path in the repo ending in .md, ignoring those under reveal.js
-for infile in `find . | grep '\.md$' | grep -v 'reveal\.js'`; do
+for infile in `find . -type f -name '*.md' | grep -v 'reveal\.js'`; do
     # derive HTML page title from header of MD file
     lineone=`head -1 $infile`
     # derive output file name (replace .md with .html)

--- a/utils/convert-markdown-to-html
+++ b/utils/convert-markdown-to-html
@@ -1,19 +1,13 @@
 #!/bin/bash
 
-for infile in `ls *.md`; do
+# take every path in the repo ending in .md, ignoring those under reveal.js
+for infile in `find . | grep '\.md$' | grep -v 'reveal\.js'`; do
+    # derive HTML page title from header of MD file
     lineone=`head -1 $infile`
+    # derive output file name (replace .md with .html)
     outfile=`echo $infile | sed 's/md$/html/g'`
-    pandoc -V "pagetitle:$lineone" -f markdown -c markdown.css -t html -o $outfile $infile
-done
-
-for infile in `ls */*.md`; do
-    lineone=`head -1 $infile`
-    outfile=`echo $infile | sed 's/md$/html/g'`
-    pandoc -V "pagetitle:$lineone" -f markdown -c ../markdown.css -t html -o $outfile $infile
-done
-
-for infile in `ls */*/*.md | grep -v reveal.js`; do
-    lineone=`head -1 $infile`
-    outfile=`echo $infile | sed 's/md$/html/g'`
-    pandoc -V "pagetitle:$lineone" -f markdown -c ../../markdown.css -t html -o $outfile $infile
+    # calculate relative path from any file in a subdirectory to another (CSS) in the root directory
+    pathprefix=`echo "$infile" | tr -d -c '/' | sed -r 's/^\///g' | sed -r 's/\//..\//g'`
+    # perform the conversion from MD to HTML, linking CSS in the process
+    pandoc -V "pagetitle:$lineone" -f markdown -c ${pathprefix}markdown.css -t html -o $outfile $infile
 done


### PR DESCRIPTION
Rather than repeat 3 loops that do essentially the same thing, we have just 1 loop which finds all the paths in the repo and performs the conversion. This has the benefit of generalizing to MD files that may be deeper in the directory tree.

Surprisingly, the script is a few seconds slower on my machine (from 12 to 16 seconds) -- if performance is a concern, start by looking at line 10 (`pathprefix`), which is the only significant line added to the loop.